### PR TITLE
Fixed API document issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 }
 
 test {
+    outputs.dir snippetsDir
     useJUnitPlatform()
     finalizedBy 'jacocoTestReport'
     finalizedBy 'asciidoctor'
@@ -86,17 +87,21 @@ jacocoTestCoverageVerification {
     }
 }
 
+
 asciidoctor {
-    inputs.dir snippetsDir
     configurations 'asciidoctorExtensions'
+    inputs.dir snippetsDir
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
     dependsOn test
 }
 
 task copyDocument(type: Copy) {
     dependsOn asciidoctor
-
-    from file("build/docs/asciidoc")
-    into file("src/main/resources/static/docs")
+    from file("${asciidoctor.outputDir}")
+    into file("build/resources/main/static")
 }
 
 bootJar {


### PR DESCRIPTION
### Change Focused

- build.gradle 파일의 test, asciidoctor, copyDocument 명령어를 수정했습니다.

### Issue - #9

### Description

jar로 빌드 후 경로가 변경이 되어 발생하는 문제였습니다.

#### as-is


```gradle
task copyDocument(type: Copy) {
    dependsOn asciidoctor
    from file("build/docs/asciidoc")
    into file("build/resources/main/static")
}
```

#### to-be

```gradle
task copyDocument(type: Copy) {
    dependsOn asciidoctor
    from file("${asciidoctor.outputDir}")
    into file("build/resources/main/static")
}

```

절대 경로가 아닌 상대 경로를 활용해 html 파일이 존재하는 위치에서 파일을 찾고, 복사를 진행했습니다.
