### PR TITLE
Solved Custom extension deletion does not proceed

### DIFF
--- a/src/main/java/hello/tis/specificextensionblocking/api/domain/ExtensionRepository.java
+++ b/src/main/java/hello/tis/specificextensionblocking/api/domain/ExtensionRepository.java
@@ -1,6 +1,7 @@
 package hello.tis.specificextensionblocking.api.domain;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Extension 저장소 인터페이스입니다. Extension 은 크게 고정 Extension 과 커스텀 Extension 으로 나뉩니다.
@@ -12,5 +13,7 @@ public interface ExtensionRepository {
   List<Extension> findAll();
 
   void delete(Extension entity);
+
+  Optional<Extension> findByName(String name);
 
 }

--- a/src/main/java/hello/tis/specificextensionblocking/api/infra/JpaExtensionRepository.java
+++ b/src/main/java/hello/tis/specificextensionblocking/api/infra/JpaExtensionRepository.java
@@ -3,6 +3,7 @@ package hello.tis.specificextensionblocking.api.infra;
 import hello.tis.specificextensionblocking.api.domain.Extension;
 import hello.tis.specificextensionblocking.api.domain.ExtensionRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -19,4 +20,6 @@ public interface JpaExtensionRepository extends JpaRepository<Extension, Long>,
 
   @Override
   void delete(Extension entity);
+
+  Optional<Extension> findByName(String name);
 }

--- a/src/main/java/hello/tis/specificextensionblocking/api/service/ExtensionService.java
+++ b/src/main/java/hello/tis/specificextensionblocking/api/service/ExtensionService.java
@@ -74,15 +74,18 @@ public class ExtensionService {
    */
   @Transactional
   public void clear(ExtensionRequest extensionRequest) {
+    Extension ex = extensionRepository.findByName(extensionRequest.getName())
+        .orElseThrow(ClearedExtensionException::new);
+
+    if (ex instanceof CustomExtension) {
+      extensionRepository.delete(ex);
+    }
+
     ConfiguredExtension extension = configuredExtensionRepository.findAll().stream()
         .filter(
             configuredExtension -> configuredExtension.getExtension().getName()
                 .equals(extensionRequest.getName())
         ).findFirst().orElseThrow(ClearedExtensionException::new);
-
-    if (extension.getExtension() instanceof CustomExtension) {
-      extensionRepository.delete(extension.getExtension());
-    }
 
     configuredExtensionRepository.delete(extension);
   }

--- a/src/test/java/hello/tis/specificextensionblocking/acceptance/ExtensionAcceptanceTest.java
+++ b/src/test/java/hello/tis/specificextensionblocking/acceptance/ExtensionAcceptanceTest.java
@@ -74,7 +74,7 @@ class ExtensionAcceptanceTest {
     // then
     ResultActions 해제_후_조회 = 조회_요청();
     해제_후_조회.andExpect(content().string(
-            Matchers.containsString("{\"customExtensionResponses\":[]}}")
+            Matchers.containsString("{\"name\":\"" + 고정_확장자 + "\",\"checked\":false}")
         )
     );
   }
@@ -93,7 +93,7 @@ class ExtensionAcceptanceTest {
 
     //then
     ResultActions 추가_후_조회 = 조회_요청();
-    추가_후_조회.andExpect(content().string(Matchers.containsString("\"" + 커스텀_확장자 + "\":\"yml\"")));
+    추가_후_조회.andExpect(content().string(Matchers.containsString("\"name\":\"" + 커스텀_확장자 + "\"")));
 
     // when
     ResultActions 확장자_해제 = 확장자_해제(커스텀_확장자);
@@ -101,7 +101,8 @@ class ExtensionAcceptanceTest {
 
     // then
     ResultActions 해제_후_조회 = 조회_요청();
-    해제_후_조회.andExpect(content().string(Matchers.containsString("\"" + 커스텀_확장자 + "\":\"yml\"")));
+    해제_후_조회.andExpect(
+        content().string(Matchers.containsString("{\"customExtensionResponses\":[]}}")));
   }
 
   /**

--- a/src/test/java/hello/tis/specificextensionblocking/api/fake/FakeExtensionRepository.java
+++ b/src/test/java/hello/tis/specificextensionblocking/api/fake/FakeExtensionRepository.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class FakeExtensionRepository implements ExtensionRepository {
 
@@ -39,5 +40,12 @@ public class FakeExtensionRepository implements ExtensionRepository {
   @Override
   public void delete(Extension entity) {
     extensionMap.remove(entity.getId());
+  }
+
+  @Override
+  public Optional<Extension> findByName(String name) {
+    return extensionMap.values().stream()
+        .filter(extension -> extension.getName().equals(name))
+        .findFirst();
   }
 }

--- a/src/test/java/hello/tis/specificextensionblocking/api/service/ExtensionServiceTest.java
+++ b/src/test/java/hello/tis/specificextensionblocking/api/service/ExtensionServiceTest.java
@@ -128,6 +128,16 @@ class ExtensionServiceTest {
     ).isInstanceOf(AddedExtensionException.class);
   }
 
+  @Test
+  @DisplayName("저장되어 있지 않은 확장자를 해제할 경우 해제 예외(clearedExtensionException)가 발생한다.")
+  void clear_NoData() {
+    String 존재하지_않은_확장자_명 = "nodataextensionname";
+    ExtensionRequest 존재하지_않은_확장자 = new ExtensionRequest(존재하지_않은_확장자_명);
+    assertThatThrownBy(
+        () -> extensionService.clear(존재하지_않은_확장자)
+    ).isInstanceOf(ClearedExtensionException.class);
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {설정되지_않은_고정_확장자, 설정되지_않은_커스텀_확장자})
   @DisplayName("설정되지 않은 확장자(UncheckedExtension)를 해제할 경우 해제 예외(clearedExtensionException)가 발생한다.")


### PR DESCRIPTION
### Issue

- 커스텀 사용자를 삭제하는 경우 삭제가 안됐습니다.

### Description

- 커스텀 사용자인지 확인하고 맞으면 삭제할 수 있도록 비즈니스 로직을 수정했습니다.
- 삭제가 안되는 상황과 관련된 유즈 케이스와 테스트를 추가했습니다.